### PR TITLE
feat(subcmd: `deploy`): add a arg `server-addr` to `deploy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "illa"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "illa"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["ILLA <opensource@illasoft.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Add a new arg `server-addr` to subcommand `deploy` that works for self-hosted installation on a cloud server.