### PR TITLE
feat!: add mount local dir functionality and add `--data` arg for subcommand `remove`

### DIFF
--- a/src/command/deploy.rs
+++ b/src/command/deploy.rs
@@ -14,7 +14,7 @@ use std::fmt::format;
 use std::hash::Hash;
 use std::thread;
 use std::time::{Duration, Instant};
-use std::{process, string};
+use std::{env, process, string};
 use uuid::Uuid;
 
 const ILLA_BUILDER_IMAGE: &str = "illasoft/illa-builder";
@@ -185,7 +185,9 @@ async fn deploy_self_host(
             host_ip: Some("0.0.0.0".to_string()),
         }]),
     );
-    utils::local_bind_init();
+    if env::consts::OS == "macos" {
+        utils::local_bind_init();
+    }
     let mounts = vec![Mount {
         target: Some("/var/lib/postgresql/data".to_string()),
         source: Some("/tmp/illa-data".to_string()),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,3 +7,4 @@ pub mod restart;
 pub mod stop;
 pub mod ui;
 pub mod update;
+pub mod utils;

--- a/src/command/remove.rs
+++ b/src/command/remove.rs
@@ -26,13 +26,17 @@ pub struct Cmd {
     /// If the ILLA Builder is running, kill it before removing it
     #[clap(short = 'f', long = "force", action = SetTrue)]
     force: bool,
+
+    /// Remove the persistent data of ILLA Builder
+    #[clap(short = 'd', long = "data", action = SetTrue)]
+    data: bool,
 }
 
 impl Cmd {
     pub async fn run(&self) -> Result {
         let (self_host, cloud) = (self.self_host, self.cloud);
         match (self_host, cloud) {
-            (true, _) => remove_local(self.force).await?,
+            (true, _) => remove_local(self.force, self.data).await?,
             (_, true) => println!("{} Looking forward to onboarding you!", ui::emoji::DIAMOND),
             _ => unreachable!(),
         };
@@ -40,8 +44,12 @@ impl Cmd {
     }
 }
 
-async fn remove_local(is_force: bool) -> Result {
+async fn remove_local(is_force: bool, data: bool) -> Result {
     println!("{} Trying to remove the ILLA Builder...", ui::emoji::BUILD);
+
+    if data {
+        utils::local_bind_delete();
+    }
 
     let _docker = Docker::connect_with_local_defaults().unwrap();
     if (_docker.ping().await).is_err() {

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -6,7 +6,7 @@ use bollard::{
         RemoveContainerOptions, StartContainerOptions, StatsOptions,
     },
     image::CreateImageOptions,
-    models::HostConfig,
+    models::{HostConfig, Mount, MountTypeEnum},
     Docker,
 };
 use clap::{builder, ArgAction::SetTrue, ArgGroup, Args};
@@ -101,6 +101,14 @@ async fn update_local(progress_style: ProgressStyle) -> Result {
         builder_env_cp[1].as_str(),
         builder_env_cp[2].as_str(),
     ];
+    utils::local_bind_init();
+    let mounts = vec![Mount {
+        target: Some("/var/lib/postgresql/data".to_string()),
+        source: Some("/tmp/illa-data".to_string()),
+        typ: Some(MountTypeEnum::BIND),
+        read_only: Some(false),
+        ..Default::default()
+    }];
     let mut builder_labels = HashMap::new();
     builder_labels.insert("maintainer", "opensource@illasoft.com");
     builder_labels.insert("license", "Apache-2.0");
@@ -189,11 +197,7 @@ async fn update_local(progress_style: ProgressStyle) -> Result {
         labels: Some(builder_labels),
         host_config: Some(HostConfig {
             port_bindings: builder_port_bindings.clone(),
-            // TODO: based on different operating system to bind host path and volume
-            // binds: Some(vec![format!(
-            //     "{}:{}",
-            //     "/tmp/illa-data", "/var/lib/postgresql/data"
-            // )]),
+            mounts: Some(mounts),
             ..Default::default()
         }),
         ..Default::default()

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -1,16 +1,29 @@
 use crate::{command::*, result::Result};
 use anyhow::Ok;
-use std::os::unix::fs::PermissionsExt;
 use std::{env, fs};
 
+#[cfg(target_os = "macos")]
 pub fn local_bind_init() -> Result {
-    if env::consts::OS == "macos" {
-        // check the local directory
-        fs::create_dir_all("/tmp/illa-data");
-        let mut perms = fs::metadata("/tmp/illa-data")?.permissions();
-        perms.set_mode(0o777);
-        fs::set_permissions("/tmp/illa-data", perms);
-    }
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all("/tmp/illa-data");
+    let mut perms = fs::metadata("/tmp/illa-data")?.permissions();
+    perms.set_mode(0o777);
+    fs::set_permissions("/tmp/illa-data", perms);
 
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn local_bind_init() -> Result {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn local_bind_init() -> Result {
+    Ok(())
+}
+
+pub fn local_bind_delete() -> Result {
+    fs::remove_dir_all("/tmp/illa-data");
     Ok(())
 }

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -1,0 +1,16 @@
+use crate::{command::*, result::Result};
+use anyhow::Ok;
+use std::os::unix::fs::PermissionsExt;
+use std::{env, fs};
+
+pub fn local_bind_init() -> Result {
+    if env::consts::OS == "macos" {
+        // check the local directory
+        fs::create_dir_all("/tmp/illa-data");
+        let mut perms = fs::metadata("/tmp/illa-data")?.permissions();
+        perms.set_mode(0o777);
+        fs::set_permissions("/tmp/illa-data", perms);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- Add support for persistence of ILLA Builder; the default local directory path is `/tmp/illa-data`. And now customization is not supported.
- Add new arg `--data` for subcommand `remove` that will support removing the persistent data of ILLA Builder.